### PR TITLE
Fix overflow issue on thumbnail preview

### DIFF
--- a/lib/components/VimeoInput/styles/VimeoInput.css
+++ b/lib/components/VimeoInput/styles/VimeoInput.css
@@ -21,7 +21,7 @@
 
 .thumbnail {
   display: block;
-  height: 100%;
+  height: auto;
   vertical-align: bottom;
   width: 100%;
 }


### PR DESCRIPTION
The 100% height causes thumbnails to bleed into the spacing between the following field. Setting it back to `auto` allows the image to scale proportionally while maintaining the correct spacing.